### PR TITLE
Updating project files and link references with new name.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Here are a few guidelines to follow when submitting a pull request:
 4. Once you are ready to submit a pull request, push your branch up to the repo.
 5. Submit your pull request against `18f-pages-staging` branch.
 
-Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/govt-wide-patternlibrary/issues](https://github.com/18F/govt-wide-patternlibrary/issues).
+Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/usfwds/issues](https://github.com/18F/usfwds/issues).
 
 ## Public domain
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Government Wide Pattern Library
+# U.S. Federal Web Design Standards
 
-[![Build Status](https://api.travis-ci.org/18F/govt-wide-patternlibrary.svg?branch=18f-pages-staging)](https://travis-ci.org/18F/govt-wide-patternlibrary)
+[![Build Status](https://api.travis-ci.org/18F/usfwds.svg?branch=18f-pages-staging)](https://travis-ci.org/18F/usfwds)
 
-This is the repo for the government wide pattern library project.
+This is the repo for the U.S. Federal Web Design Standards project.
 The structural setup of this repo is based off of the 18F pages project: 
 [https://github.com/18F/pages](https://github.com/18F/pages)
 
@@ -31,16 +31,16 @@ Now that you have verified that you have Ruby installed, clone and run the
 following [go](https://golang.org/) commands to initialize and serve the library locally.
 
 ```shell
-$ git clone git@github.com:18F/govt-wide-patternlibrary.git
-$ cd govt-wide-patternlibrary
+$ git clone git@github.com:18F/usfwds.git
+$ cd usfwds
 $ ./go init
 $ ./go serve
 ```
 
-You should now be able to visit `http://127.0.0.1:4000/govt-wide-patternlibrary/` 
-and view the pattern library locally.
+You should now be able to visit `http://127.0.0.1:4000/usfwds/` 
+and view the web design standards locally.
 
-Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/govt-wide-patternlibrary/issues](https://github.com/18F/govt-wide-patternlibrary/issues).
+Questions or need help with setup? Feel free to open an issue here [https://github.com/18F/usfwds/issues](https://github.com/18F/usfwds/issues).
 
 
 ### Public domain

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,12 @@
 # 18F pages base url config
-baseurl: /govt-wide-patternlibrary
+baseurl: /usfwds
 
-url: https://pages.18f.gov/govt-wide-patternlibrary
+url: https://pages.18f.gov/usfwds
 
 # Markdown config
 markdown: redcarpet
 highlighter: rouge
-name: Government Wide Pattern Library
+name: U.S. Federal Web Design Standards
 exclude:
 - go
 - Gemfile
@@ -21,9 +21,9 @@ exclude:
 permalink: pretty
 
 repos:
-- name: Government Wide Pattern Library
-  description: Main repository for the Government Wide Pattern Library.
-  url: https://github.com/18F/govt-wide-patternlibrary
+- name: U.S. Federal Web Design Standards
+  description: Main repository for the U.S. Federal Web Design Standards.
+  url: https://github.com/18F/usfwds
 
 google_analytics_ua: UA-48605964-19
 

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -14,7 +14,7 @@
     <a href="#" id="menu-btn">&#9776; MENU</a>
     <div id="logo">
       <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
-        <h1>Government Wide Pattern Library</h1>
+        <h1>U.S. Federal Web Design Standards</h1>
       </a>
     </div>
     <ul class="usa-unstyled-list">
@@ -22,7 +22,7 @@
         <a href="{{ site.baseurl }}/about/">About</a>
       </li>
       <li>
-        <a href="https://github.com/18F/govt-wide-patternlibrary/" target="_blank">
+        <a href="https://github.com/18F/usfwds/" target="_blank">
           View on Github
         </a>
         </li>

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -386,7 +386,7 @@ header[role="banner"] {
   }
 }
 
-// Custom styles to illustrate invisible grid for pattern library
+// Custom styles to illustrate invisible grid for web design standards
 
 .usa-grid-example {
   background: $color-grid-light;

--- a/pages/about.html
+++ b/pages/about.html
@@ -6,10 +6,10 @@ title: About
 
 <h1>About</h1>
 
-<p>Welcome to the alpha site for the US Government web pattern library project. </p>
+<p>Welcome to the alpha site for the U.S. Federal Web Design Standards project. </p>
 
-<p>This pattern library is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>This web design standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
-<p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="https://github.com/18F/govt-wide-patternlibrary/issues">https://github.com/18F/govt-wide-patternlibrary/issues</a>.</p>
+<p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="https://github.com/18F/usfwds/issues">https://github.com/18F/usfwds/issues</a>.</p>
 
-<p>The US Government web pattern library project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the Federal Government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The U.S. Federal Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the Federal Government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>

--- a/pages/about.html
+++ b/pages/about.html
@@ -8,7 +8,7 @@ title: About
 
 <p>Welcome to the alpha site for the U.S. Federal Web Design Standards project. </p>
 
-<p>This web design standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>The web design standards are intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
 <p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="https://github.com/18F/usfwds/issues">https://github.com/18F/usfwds/issues</a>.</p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,18 +1,18 @@
 ---
 permalink: /
 layout: styleguide
-title: Government Wide Pattern Library
+title: U.S. Federal Web Design Standards
 ---
 
 <h1>About this Guide</h1> 
 
-<p>Welcome to the alpha site for the US Government web pattern library project.</p> 
+<p>Welcome to the alpha site for the U.S. Federal Web Design Standards project.</p> 
 
-<p>This pattern library is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
+<p>This web design standards is intended to provide reference for designers, developers, as well as anyone else interested in the design and frontend principles that make up the building blocks of federal government websites.</p>
 
-<p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="https://github.com/18F/govt-wide-patternlibrary/issues">https://github.com/18F/govt-wide-patternlibrary/issues</a>.</p> 
+<p>This site is currently under development and your feedback is important to us. We encourage you to contribute your input at <a href="https://github.com/18F/usfwds/issues">https://github.com/18F/usfwds/issues</a>.</p> 
 
-<p>The US Government web pattern library project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the Federal Government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
+<p>The U.S. Federal Web Design Standards project is a partnership of the <a href="https://whitehouse.gov/usds">U.S. Digital Service</a> and <a href="https://18f.gsa.gov">18F</a> with the support of partners across the Federal Government. If you'd like to learn more, please send a note to <a href="mailto:govtwidepatternlibrary@gsa.gov">govtwidepatternlibrary@gsa.gov</a>.</p>
 
 <h1>Visual Style</h1>
 


### PR DESCRIPTION
The name has been changed from "Government-wide Pattern Library" to "U.S. Federal Web Design Standards" by the team and stakeholders. This pull request updates this in all of the files throughout the site.