### PR TITLE
Downgrading Jekyll to 2.4.0 and removing -webkit reference on inputs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll'
+gem 'jekyll', '2.4.0'
 
 gem 'rouge'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     autoprefixer-rails (2.2.0.20140804)
       execjs
     blankslate (2.1.2.4)
-    celluloid (0.16.0)
+    celluloid (0.16.1)
       timers (~> 4.0.0)
     classifier-reborn (2.0.3)
       fast-stemmer (~> 1.0)
@@ -15,9 +15,9 @@ GEM
     colorator (0.1)
     execjs (2.5.2)
     fast-stemmer (1.0.2)
-    ffi (1.9.8)
+    ffi (1.9.10)
     hitimes (1.2.2)
-    jekyll (2.5.3)
+    jekyll (2.4.0)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
       jekyll-coffeescript (~> 1.0)
@@ -34,15 +34,15 @@ GEM
       toml (~> 0.1.0)
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
-    jekyll-gist (1.2.1)
+    jekyll-gist (1.3.0)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
     jekyll-watch (1.2.1)
       listen (~> 2.7)
-    kramdown (1.6.0)
-    liquid (2.6.2)
-    listen (2.10.0)
+    kramdown (1.8.0)
+    liquid (2.6.3)
+    listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -59,13 +59,13 @@ GEM
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.2.3)
+    redcarpet (3.3.2)
     rouge (1.8.0)
     safe_yaml (1.0.4)
-    sass (3.4.13)
+    sass (3.4.16)
     timers (4.0.1)
       hitimes
     toml (0.1.2)
@@ -76,7 +76,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll
+  jekyll (= 2.4.0)
   octopress-autoprefixer
   redcarpet
   rouge
+
+BUNDLED WITH
+   1.10.5

--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -26,7 +26,7 @@ select  {
   width: 100%;
   outline: none;
   padding: 1rem .7em;
-  -webkit-appearance: none;
+  appearance: none;
 
   &:focus, 
   &.usa-input-focus {


### PR DESCRIPTION
This pull request is a continuation of the work started on adding autoprefixer here: https://github.com/18F/usfwds/pull/283

A few things to note:

- After some testing, in order for the plugin to work, we'll have to downgrade our version of Jekyll to 2.4.0. This PR implements that change.
- There are a few spots in the styles in which we use singular prefixes, specifically for `-webkit`. Looks like those stay in as they are for now: 

https://github.com/18F/usfwds/blob/96075d5908a8d792188a653dd8ca467de8c50bb7/assets/_scss/elements/_buttons.scss#L28

https://github.com/18F/usfwds/blob/96075d5908a8d792188a653dd8ca467de8c50bb7/assets/css/styleguide.scss#L127