### PR TITLE
Add margin to labels

### DIFF
--- a/assets/_scss/elements/_labels.scss
+++ b/assets/_scss/elements/_labels.scss
@@ -11,6 +11,10 @@
     top: 0.3rem;
   }
   text-transform: uppercase;
+
+  &:only-of-type {
+    margin-right: 0;
+  }
 }
 
 .usa-label-big {

--- a/assets/_scss/elements/_labels.scss
+++ b/assets/_scss/elements/_labels.scss
@@ -3,6 +3,7 @@
   border-radius: $border-radius;
   color: $color-white;
   font-size: $small-font-size;
+  margin-right: .5rem;
   padding: {
     bottom: 0.1rem;
     left: 0.7rem;


### PR DESCRIPTION
This adds a right margin to labels so that if there are multiple labels on the same line they have space between them.

This is what it looks like:
<img width="436" alt="screen shot 2015-08-17 at 9 21 04 am" src="https://cloud.githubusercontent.com/assets/5249443/9309872/291b37b0-44c1-11e5-940e-bc46095a3dc8.png">

Without it:
<img width="410" alt="screen shot 2015-08-17 at 9 23 16 am" src="https://cloud.githubusercontent.com/assets/5249443/9309899/489d1c52-44c1-11e5-814d-155e89af5903.png">
