### PR TITLE
Update typography

### DIFF
--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -45,11 +45,11 @@ title: Alerts
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_components/alerts.md
+++ b/_components/alerts.md
@@ -45,11 +45,11 @@ title: Alerts
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_components/footers.md
+++ b/_components/footers.md
@@ -6,7 +6,7 @@ title: Footers
 
 <div class="preview">
 
-  <h3 class="usa-usfwds-heading">Footer Big</h3>
+  <h3 class="usa-heading">Footer Big</h3>
 
   <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -101,7 +101,7 @@ title: Footers
     </div>
   </footer>
 
-  <h3 class="usa-usfwds-heading">Footer Medium</h3>
+  <h3 class="usa-heading">Footer Medium</h3>
 
   <footer class="usa-footer usa-footer-medium usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -176,7 +176,7 @@ title: Footers
     </div>
   </footer>
 
-  <h3 class="usa-usfwds-heading">Footer Slim</h3>
+  <h3 class="usa-heading">Footer Slim</h3>
 
   <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -232,7 +232,7 @@ title: Footers
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Footers serve site visitors who arrive at the bottom of a page without finding what they want.</li>
       <li>Footer links should point to popular content that might answer a visitor’s remaining questions. Links to disclaimers and legal content sometimes need to be in the footer, but try to minimize “disclaimer bloat” wherever possible.</li>
@@ -243,7 +243,7 @@ title: Footers
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <ul>
       <li>Code the navigation so that pressing the  tab key moves focus from link to link in the navigation, even when the navigation has collapsed into an accordion.</li>
       <li>On small screens: when collapsed into an accordion, the navigation should also meet the accessibility requirements outlined in the "Accordion" section.</li>

--- a/_components/footers.md
+++ b/_components/footers.md
@@ -6,7 +6,7 @@ title: Footers
 
 <div class="preview">
 
-  <h3>Footer Big</h3>
+  <h3 class="usa-usfwds-heading">Footer Big</h3>
 
   <footer class="usa-footer usa-footer-big usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -101,7 +101,7 @@ title: Footers
     </div>
   </footer>
 
-  <h3>Footer Medium</h3>
+  <h3 class="usa-usfwds-heading">Footer Medium</h3>
 
   <footer class="usa-footer usa-footer-medium usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -176,7 +176,7 @@ title: Footers
     </div>
   </footer>
 
-  <h3>Footer Slim</h3>
+  <h3 class="usa-usfwds-heading">Footer Slim</h3>
 
   <footer class="usa-footer usa-footer-slim usa-sans" role="contentinfo">
     <div class="usa-grid usa-footer-return-to-top">
@@ -232,7 +232,7 @@ title: Footers
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Footers serve site visitors who arrive at the bottom of a page without finding what they want.</li>
       <li>Footer links should point to popular content that might answer a visitor’s remaining questions. Links to disclaimers and legal content sometimes need to be in the footer, but try to minimize “disclaimer bloat” wherever possible.</li>
@@ -243,7 +243,7 @@ title: Footers
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <ul>
       <li>Code the navigation so that pressing the  tab key moves focus from link to link in the navigation, even when the navigation has collapsed into an accordion.</li>
       <li>On small screens: when collapsed into an accordion, the navigation should also meet the accessibility requirements outlined in the "Accordion" section.</li>

--- a/_components/form-blocks.md
+++ b/_components/form-blocks.md
@@ -4,7 +4,7 @@ type: component
 title: Forms Blocks
 ---
 
-<h3>Accessibility</h3>
+<h3 class="usa-usfwds-heading">Accessibility</h3>
 
 <p>As you customize these templates, ensure they continue to meet the <a href="{{ site.baseurl }}/elements/#inputs">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
 
@@ -106,7 +106,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>As you customize this form, ensure it continues to:</p>
     <ul>
       <li>Label the optional ones. Users can infer that all the others are required.</li>
@@ -114,7 +114,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -154,14 +154,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Leave the title and suffix fields as text boxes (instead of offering drop downs.) There are many possible titles and suffixes; text boxes accommodate them all.</li>
       <li>Do not restrict the types of characters users can enter in any of these fields. Names can include characters outside the standard Roman alphabet.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -196,14 +196,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Don’t ask for a social security number unless it’s absolutely essential. Users are reluctant to divulge personal information unless the reason for why it’s needed is clear.  If it’s not clear why it’s needed, offer an explanation.</li>
       <li>Allow users to show or hide their entry so they can check for errors.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -249,7 +249,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Sign in forms are a barrier between users and the content they want, so allow users to access as much as of your online services as possible without having to log in.</li>
       <li>People have an easier time remembering their email address rather than a unique username, so allow them to use their email address to log in. However, some people don’t have an email address, so don’t let this be the only option.</li>
@@ -259,7 +259,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -272,7 +272,7 @@ title: Forms Blocks
   </div>  
 </div>
 
-<h2>Password Reset</h2>
+<h2 class="usa-usfwds-heading">Password Reset</h2>
 
 <div class="preview">
   <form>
@@ -319,7 +319,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Most authentication failures occur because a user has forgotten their username or password. This is especially common when a long time passes between visits, as is the case with most federal websites.</li>
       <li>State any password requirements (e.g. "Must include one capital letter") upfront. Don’t leave users guessing only to hit them with an error message later.</li>
@@ -327,7 +327,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <ul>
       <li>Using aria-describedby is a good way to associate the password strength information with the field.</li>
     </ul>
@@ -339,7 +339,7 @@ title: Forms Blocks
   </div>  
 </div>
 
-<h2>Contact Form</h2>
+<h2 class="usa-usfwds-heading">Contact Form</h2>
 
 <div class="preview">
   
@@ -374,14 +374,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Avoid adding too many fields to this form – the more you add, the less likely people are to complete the form. This is especially true if you ask for unnecessary personal information, such as phone numbers, that people may not be ready to give out.</li>
       <li>Wherever possible, include a direct email address and phone number on your form. Some users may prefer to write an email or call.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>

--- a/_components/form-blocks.md
+++ b/_components/form-blocks.md
@@ -4,7 +4,7 @@ type: component
 title: Forms Blocks
 ---
 
-<h3 class="usa-usfwds-heading">Accessibility</h3>
+<h3 class="usa-heading">Accessibility</h3>
 
 <p>As you customize these templates, ensure they continue to meet the <a href="{{ site.baseurl }}/elements/#inputs">accessibility guidelines for all form controls</a> as well as the accessibility guidelines for each individual control.</p>
 
@@ -106,7 +106,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>As you customize this form, ensure it continues to:</p>
     <ul>
       <li>Label the optional ones. Users can infer that all the others are required.</li>
@@ -114,7 +114,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -154,14 +154,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Leave the title and suffix fields as text boxes (instead of offering drop downs.) There are many possible titles and suffixes; text boxes accommodate them all.</li>
       <li>Do not restrict the types of characters users can enter in any of these fields. Names can include characters outside the standard Roman alphabet.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -196,14 +196,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Don’t ask for a social security number unless it’s absolutely essential. Users are reluctant to divulge personal information unless the reason for why it’s needed is clear.  If it’s not clear why it’s needed, offer an explanation.</li>
       <li>Allow users to show or hide their entry so they can check for errors.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -249,7 +249,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Sign in forms are a barrier between users and the content they want, so allow users to access as much as of your online services as possible without having to log in.</li>
       <li>People have an easier time remembering their email address rather than a unique username, so allow them to use their email address to log in. However, some people don’t have an email address, so don’t let this be the only option.</li>
@@ -259,7 +259,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>
@@ -272,7 +272,7 @@ title: Forms Blocks
   </div>  
 </div>
 
-<h2 class="usa-usfwds-heading">Password Reset</h2>
+<h2 class="usa-heading">Password Reset</h2>
 
 <div class="preview">
   <form>
@@ -319,7 +319,7 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Most authentication failures occur because a user has forgotten their username or password. This is especially common when a long time passes between visits, as is the case with most federal websites.</li>
       <li>State any password requirements (e.g. "Must include one capital letter") upfront. Don’t leave users guessing only to hit them with an error message later.</li>
@@ -327,7 +327,7 @@ title: Forms Blocks
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <ul>
       <li>Using aria-describedby is a good way to associate the password strength information with the field.</li>
     </ul>
@@ -339,7 +339,7 @@ title: Forms Blocks
   </div>  
 </div>
 
-<h2 class="usa-usfwds-heading">Contact Form</h2>
+<h2 class="usa-heading">Contact Form</h2>
 
 <div class="preview">
   
@@ -374,14 +374,14 @@ title: Forms Blocks
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Avoid adding too many fields to this form – the more you add, the less likely people are to complete the form. This is especially true if you ask for unnecessary personal information, such as phone numbers, that people may not be ready to give out.</li>
       <li>Wherever possible, include a direct email address and phone number on your form. Some users may prefer to write an email or call.</li>
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>

--- a/_components/headers.md
+++ b/_components/headers.md
@@ -11,11 +11,11 @@ title: Headers & Navigation
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_components/headers.md
+++ b/_components/headers.md
@@ -11,11 +11,11 @@ title: Headers & Navigation
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -61,7 +61,7 @@ title: Search Bar
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <ul>
       <li>Allow the search bar to be as wide as possible, but a minimum of 27 characters wide. This allows users to enter multiple search terms without their inputs being obscured. The more users can see their search terms, the easier it is to review, verify, and submit their search query.</li>
       <li>The magnifying glass has been shown to be almost universally recognized by users as an indicator of search functionality and doesn’t need to be paired with the word "Search" (except for screen readers, see the accessibility guidelines).</li>
@@ -73,7 +73,7 @@ title: Search Bar
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>

--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -61,7 +61,7 @@ title: Search Bar
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <ul>
       <li>Allow the search bar to be as wide as possible, but a minimum of 27 characters wide. This allows users to enter multiple search terms without their inputs being obscured. The more users can see their search terms, the easier it is to review, verify, and submit their search query.</li>
       <li>The magnifying glass has been shown to be almost universally recognized by users as an indicator of search functionality and doesn’t need to be paired with the word "Search" (except for screen readers, see the accessibility guidelines).</li>
@@ -73,7 +73,7 @@ title: Search Bar
     </ul>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>As you customize this form template, ensure it continues to follow the:</p>
     <ul>
       <li><a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines for form templates</a> and</li>

--- a/_components/search-results.md
+++ b/_components/search-results.md
@@ -11,11 +11,11 @@ title: Search Results
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_components/search-results.md
+++ b/_components/search-results.md
@@ -11,11 +11,11 @@ title: Search Results
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/buttons.md
+++ b/_elements/buttons.md
@@ -7,7 +7,7 @@ title: Buttons
 <div class="preview">
   <!-- Add HTML markup for example here -->
 
-  <h3>Primary Buttons</h3>
+  <h3 class="usa-usfwds-heading">Primary Buttons</h3>
   <div class="button_wrapper">
     <button>Default</button>
     <button class="usa-button-active">Active</button>
@@ -19,7 +19,7 @@ title: Buttons
     <button class="usa-button-primary-alt usa-button-hover">Hover</button>
   </div>
 
-  <h3>Secondary Buttons</h3>
+  <h3 class="usa-usfwds-heading">Secondary Buttons</h3>
   <div class="button_wrapper">
     <button class="usa-button-secondary">Default</button>
     <button class="usa-button-secondary usa-button-active">Active</button>
@@ -44,19 +44,19 @@ title: Buttons
     <button class="usa-button-outline-inverse usa-button-hover">Hover</button>
   </div>
 
-  <h3>Button Focus</h3>
+  <h3 class="usa-usfwds-heading">Button Focus</h3>
   <div class="button_wrapper">
     <button class="usa-button-focus">Default</button>
     <button class="usa-button-primary-alt usa-button-focus">Default</button>
     <button class="usa-button-secondary usa-button-focus">Default</button>
   </div>
 
-  <h3>Disabled Button</h3>
+  <h3 class="usa-usfwds-heading">Disabled Button</h3>
   <div class="button_wrapper">
     <button class="usa-button-disabled">Default</button>
   </div>
 
-  <h3>Big Button</h3>
+  <h3 class="usa-usfwds-heading">Big Button</h3>
   <div class="button_wrapper">
     <button class="usa-button-big" type="button">Default</button>
   </div>
@@ -65,11 +65,11 @@ title: Buttons
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/buttons.md
+++ b/_elements/buttons.md
@@ -7,7 +7,7 @@ title: Buttons
 <div class="preview">
   <!-- Add HTML markup for example here -->
 
-  <h3 class="usa-usfwds-heading">Primary Buttons</h3>
+  <h3 class="usa-heading">Primary Buttons</h3>
   <div class="button_wrapper">
     <button>Default</button>
     <button class="usa-button-active">Active</button>
@@ -19,7 +19,7 @@ title: Buttons
     <button class="usa-button-primary-alt usa-button-hover">Hover</button>
   </div>
 
-  <h3 class="usa-usfwds-heading">Secondary Buttons</h3>
+  <h3 class="usa-heading">Secondary Buttons</h3>
   <div class="button_wrapper">
     <button class="usa-button-secondary">Default</button>
     <button class="usa-button-secondary usa-button-active">Active</button>
@@ -44,19 +44,19 @@ title: Buttons
     <button class="usa-button-outline-inverse usa-button-hover">Hover</button>
   </div>
 
-  <h3 class="usa-usfwds-heading">Button Focus</h3>
+  <h3 class="usa-heading">Button Focus</h3>
   <div class="button_wrapper">
     <button class="usa-button-focus">Default</button>
     <button class="usa-button-primary-alt usa-button-focus">Default</button>
     <button class="usa-button-secondary usa-button-focus">Default</button>
   </div>
 
-  <h3 class="usa-usfwds-heading">Disabled Button</h3>
+  <h3 class="usa-heading">Disabled Button</h3>
   <div class="button_wrapper">
     <button class="usa-button-disabled">Default</button>
   </div>
 
-  <h3 class="usa-usfwds-heading">Big Button</h3>
+  <h3 class="usa-heading">Big Button</h3>
   <div class="button_wrapper">
     <button class="usa-button-big" type="button">Default</button>
   </div>
@@ -65,11 +65,11 @@ title: Buttons
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/inputs.md
+++ b/_elements/inputs.md
@@ -4,7 +4,7 @@ type: component
 title: Inputs
 ---
 
-<h3 class="usa-usfwds-heading">Accessibility</h3>
+<h3 class="usa-heading">Accessibility</h3>
 
 <p>As you customize form controls from this library, be sure they continue to meet the following accessibility requirements:</p>
 
@@ -19,7 +19,7 @@ title: Inputs
 
 <div class="preview">
 
-  <h2 class="usa-usfwds-heading">Text Input</h2>
+  <h2 class="usa-heading">Text Input</h2>
 
   <label for="input-type-text">Text Input Label</label>
   <input id="input-type-text" name="input-type-text" type="text">
@@ -36,14 +36,14 @@ title: Inputs
   <label for="input-success">Text Input Success</label>
   <input class="usa-input-success" id="input-success" name="input-success" type="text">
 
-  <h2 class="usa-usfwds-heading">Text Area</h2>
+  <h2 class="usa-heading">Text Area</h2>
 
   <label for="input-type-textarea">Text Area Label</label>
   <textarea id="input-type-textarea" name="input-type-textarea"></textarea>
 
 </div>
 
-<h2 class="usa-usfwds-heading">Checkboxes</h2>
+<h2 class="usa-heading">Checkboxes</h2>
 
 <div class="preview">
 
@@ -74,7 +74,7 @@ title: Inputs
 
 </div>
 
-<h2 class="usa-usfwds-heading">Radio buttons</h2>
+<h2 class="usa-heading">Radio buttons</h2>
 
 <div class="preview">
 
@@ -101,7 +101,7 @@ title: Inputs
 
 </div>
 
-<h2 class="usa-usfwds-heading">Range slider</h2>
+<h2 class="usa-heading">Range slider</h2>
 
 <div class="preview">
 
@@ -110,7 +110,7 @@ title: Inputs
 
 </div>
 
-<h2 class="usa-usfwds-heading">Dropdown</h2>
+<h2 class="usa-heading">Dropdown</h2>
 
 <div class="preview">
 <form>
@@ -123,14 +123,14 @@ title: Inputs
 </form>
 </div>
 
-<h2 class="usa-usfwds-heading">Date picker</h2>
+<h2 class="usa-heading">Date picker</h2>
 
 <div class="preview">
   <!-- Add HTML markup for example here -->
   <img src="{{ site.baseurl }}/assets/img/static/Date_Picker_UI_v1.png">
 </div>
 
-<h2 class="usa-usfwds-heading">Memorable Dates</h2>
+<h2 class="usa-heading">Memorable Dates</h2>
 
 <div class="preview">
 
@@ -157,11 +157,11 @@ title: Inputs
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/inputs.md
+++ b/_elements/inputs.md
@@ -4,7 +4,7 @@ type: component
 title: Inputs
 ---
 
-<h3>Accessibility</h3>
+<h3 class="usa-usfwds-heading">Accessibility</h3>
 
 <p>As you customize form controls from this library, be sure they continue to meet the following accessibility requirements:</p>
 
@@ -19,7 +19,7 @@ title: Inputs
 
 <div class="preview">
 
-  <h2>Text Input</h2>
+  <h2 class="usa-usfwds-heading">Text Input</h2>
 
   <label for="input-type-text">Text Input Label</label>
   <input id="input-type-text" name="input-type-text" type="text">
@@ -36,14 +36,14 @@ title: Inputs
   <label for="input-success">Text Input Success</label>
   <input class="usa-input-success" id="input-success" name="input-success" type="text">
 
-  <h2>Text Area</h2>
+  <h2 class="usa-usfwds-heading">Text Area</h2>
 
   <label for="input-type-textarea">Text Area Label</label>
   <textarea id="input-type-textarea" name="input-type-textarea"></textarea>
 
 </div>
 
-<h2>Checkboxes</h2>
+<h2 class="usa-usfwds-heading">Checkboxes</h2>
 
 <div class="preview">
 
@@ -74,7 +74,7 @@ title: Inputs
 
 </div>
 
-<h2>Radio buttons</h2>
+<h2 class="usa-usfwds-heading">Radio buttons</h2>
 
 <div class="preview">
 
@@ -101,7 +101,7 @@ title: Inputs
 
 </div>
 
-<h2>Range slider</h2>
+<h2 class="usa-usfwds-heading">Range slider</h2>
 
 <div class="preview">
 
@@ -110,7 +110,7 @@ title: Inputs
 
 </div>
 
-<h2>Dropdown</h2>
+<h2 class="usa-usfwds-heading">Dropdown</h2>
 
 <div class="preview">
 <form>
@@ -123,14 +123,14 @@ title: Inputs
 </form>
 </div>
 
-<h2>Date picker</h2>
+<h2 class="usa-usfwds-heading">Date picker</h2>
 
 <div class="preview">
   <!-- Add HTML markup for example here -->
   <img src="{{ site.baseurl }}/assets/img/static/Date_Picker_UI_v1.png">
 </div>
 
-<h2>Memorable Dates</h2>
+<h2 class="usa-usfwds-heading">Memorable Dates</h2>
 
 <div class="preview">
 
@@ -157,11 +157,11 @@ title: Inputs
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/labels.md
+++ b/_elements/labels.md
@@ -6,21 +6,21 @@ title: Labels
 
 <div class="preview">
 
-  <h3 class="usa-usfwds-heading">Small</h3>
+  <h3 class="usa-heading">Small</h3>
   <span class="usa-label">New</span>
 
-  <h3 class="usa-usfwds-heading">Large</h3>
+  <h3 class="usa-heading">Large</h3>
   <span class="usa-label-big">New</span>
 
 </div>
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/labels.md
+++ b/_elements/labels.md
@@ -6,21 +6,21 @@ title: Labels
 
 <div class="preview">
 
-  <h3>Small</h3>
+  <h3 class="usa-usfwds-heading">Small</h3>
   <span class="usa-label">New</span>
 
-  <h3>Large</h3>
+  <h3 class="usa-usfwds-heading">Large</h3>
   <span class="usa-label-big">New</span>
 
 </div>
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -6,7 +6,7 @@ title: Tables
 
 <div class="preview">
 
-  <h3>Bordered Table</h3>
+  <h3 class="usa-usfwds-heading">Bordered Table</h3>
 
   <table>
     <thead>
@@ -50,7 +50,7 @@ title: Tables
     </tbody>
   </table>
 
-  <h3>Borderless Table</h3>
+  <h3 class="usa-usfwds-heading">Borderless Table</h3>
 
   <table class="usa-table-borderless">
     <thead>
@@ -98,11 +98,11 @@ title: Tables
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_elements/tables.md
+++ b/_elements/tables.md
@@ -6,7 +6,7 @@ title: Tables
 
 <div class="preview">
 
-  <h3 class="usa-usfwds-heading">Bordered Table</h3>
+  <h3 class="usa-heading">Bordered Table</h3>
 
   <table>
     <thead>
@@ -50,7 +50,7 @@ title: Tables
     </tbody>
   </table>
 
-  <h3 class="usa-usfwds-heading">Borderless Table</h3>
+  <h3 class="usa-heading">Borderless Table</h3>
 
   <table class="usa-table-borderless">
     <thead>
@@ -98,11 +98,11 @@ title: Tables
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_layout-system/grids.md
+++ b/_layout-system/grids.md
@@ -5,7 +5,7 @@ title: Grids
 
 <div class="preview">
 
-  <h3>Grid</h3>
+  <h3 class="usa-usfwds-heading">Grid</h3>
   <div class="usa-grid usa-grid-example usa-grid-example-blank">
     <div class="usa-width-one-whole">1/1</div>
     <div class="usa-width-one-half">1/2</div>
@@ -37,7 +37,7 @@ title: Grids
     <div class="usa-width-one-twelfth usa-end-row">1/12</div>
   </div>
 
-  <h3>Grid Examples</h3>
+  <h3 class="usa-usfwds-heading">Grid Examples</h3>
   <div class="usa-grid usa-grid-example usa-grid-text">
     <div class="usa-width-one-half">
       <h3>One Half</h3>
@@ -101,11 +101,11 @@ title: Grids
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_layout-system/grids.md
+++ b/_layout-system/grids.md
@@ -5,7 +5,7 @@ title: Grids
 
 <div class="preview">
 
-  <h3 class="usa-usfwds-heading">Grid</h3>
+  <h3 class="usa-heading">Grid</h3>
   <div class="usa-grid usa-grid-example usa-grid-example-blank">
     <div class="usa-width-one-whole">1/1</div>
     <div class="usa-width-one-half">1/2</div>
@@ -37,7 +37,7 @@ title: Grids
     <div class="usa-width-one-twelfth usa-end-row">1/12</div>
   </div>
 
-  <h3 class="usa-usfwds-heading">Grid Examples</h3>
+  <h3 class="usa-heading">Grid Examples</h3>
   <div class="usa-grid usa-grid-example usa-grid-text">
     <div class="usa-width-one-half">
       <h3>One Half</h3>
@@ -101,11 +101,11 @@ title: Grids
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_layout-system/layouts.md
+++ b/_layout-system/layouts.md
@@ -10,11 +10,11 @@ title: Layouts
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_layout-system/layouts.md
+++ b/_layout-system/layouts.md
@@ -10,11 +10,11 @@ title: Layouts
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -10,11 +10,11 @@ title: Colors
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -10,11 +10,11 @@ title: Colors
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_visual/icons.md
+++ b/_visual/icons.md
@@ -11,11 +11,11 @@ title: Icons
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_visual/icons.md
+++ b/_visual/icons.md
@@ -11,11 +11,11 @@ title: Icons
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -7,7 +7,7 @@ title: Typography
   <!-- Add HTML markup for example here -->
 
   <!-- Heading title -->
-  <h3>Headings</h3>
+  <h3 class="usa-usfwds-heading">Headings</h3>
 
   <h3 class="usa-display">Display 52px in Merriweather 700</h3>
   <h1>Heading 1 in 40px in Merriweather 700</h1>
@@ -17,20 +17,20 @@ title: Typography
   <h5>Heading 5 in 14px in Merriweather 700</h5>
 
   <!-- Body title -->
-  <h3>Body</h3>
+  <h3 class="usa-usfwds-heading">Body</h3>
 
   <div class="usa-content">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
   </div>
 
   <!-- Links title -->
-  <h3>Links</h3>
+  <h3 class="usa-usfwds-heading">Links</h3>
 
   <p>This is <a href="#">linked text</a> for body copy</p>
   <p class="usa-sans">This is <a href="#">linked text</a> for everything else</p>
 
   <!-- Lists title -->
-  <h3>Lists</h3>
+  <h3 class="usa-usfwds-heading">Lists</h3>
 
   <ul>
     <li>Unordered list item</li>
@@ -66,11 +66,11 @@ title: Typography
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3>Use</h3>
+    <h3 class="usa-usfwds-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3>Accessibility</h3>
+    <h3 class="usa-usfwds-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div> 

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -9,12 +9,12 @@ title: Typography
   <!-- Heading title -->
   <h3>Headings</h3>
 
-  <h3 class="usa-display">Display 48px in Source Sans Pro 700</h3>
-  <h1>Heading 1 in 36px in Source Sans Pro 700</h1>
-  <h2>Heading 2 in 24px in Source Sans Pro 700</h2>
-  <h3>Heading 3 in 19px in Source Sans Pro 700</h3>
-  <h4>Heading 4 in 16px in Source Sans Pro 700</h4>
-  <h5>Heading 5 in 14px in Source Sans Pro 700</h5>
+  <h3 class="usa-display">Display 52px in Merriweather 700</h3>
+  <h1>Heading 1 in 40px in Merriweather 700</h1>
+  <h2>Heading 2 in 30px in Merriweather 700</h2>
+  <h3>Heading 3 in 20px in Merriweather 700</h3>
+  <h4>Heading 4 in 17px in Merriweather 700</h4>
+  <h5>Heading 5 in 14px in Merriweather 700</h5>
 
   <!-- Body title -->
   <h3>Body</h3>

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -7,7 +7,7 @@ title: Typography
   <!-- Add HTML markup for example here -->
 
   <!-- Heading title -->
-  <h3 class="usa-usfwds-heading">Headings</h3>
+  <h3 class="usa-heading">Headings</h3>
 
   <h3 class="usa-display">Display 52px in Merriweather 700</h3>
   <h1>Heading 1 in 40px in Merriweather 700</h1>
@@ -17,20 +17,20 @@ title: Typography
   <h5>Heading 5 in 14px in Merriweather 700</h5>
 
   <!-- Body title -->
-  <h3 class="usa-usfwds-heading">Body</h3>
+  <h3 class="usa-heading">Body</h3>
 
   <div class="usa-content">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
   </div>
 
   <!-- Links title -->
-  <h3 class="usa-usfwds-heading">Links</h3>
+  <h3 class="usa-heading">Links</h3>
 
   <p>This is <a href="#">linked text</a> for body copy</p>
   <p class="usa-sans">This is <a href="#">linked text</a> for everything else</p>
 
   <!-- Lists title -->
-  <h3 class="usa-usfwds-heading">Lists</h3>
+  <h3 class="usa-heading">Lists</h3>
 
   <ul>
     <li>Unordered list item</li>
@@ -66,11 +66,11 @@ title: Typography
 
 <div class="usa-grid">
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Use</h3>
+    <h3 class="usa-heading">Use</h3>
     <p>This is the usage content for the example.</p>
   </div>
   <div class="usa-width-one-half">
-    <h3 class="usa-usfwds-heading">Accessibility</h3>
+    <h3 class="usa-heading">Accessibility</h3>
     <p>This is the accessibility content for the example.</p>
   </div>  
 </div> 

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -9,14 +9,12 @@ title: Typography
   <!-- Heading title -->
   <h3>Headings</h3>
 
-  <div class="usa-typography-examples">
-    <h3 class="usa-display">Display 52px in Merriweather 700</h3>
-    <h1>Heading 1 in 40px in Merriweather 700</h1>
-    <h2>Heading 2 in 30px in Merriweather 700</h2>
-    <h3>Heading 3 in 20px in Merriweather 700</h3>
-    <h4>Heading 4 in 17px in Merriweather 700</h4>
-    <h5>Heading 5 in 14px in Merriweather 700</h5>
-  </div>
+  <h3 class="usa-display">Display 52px in Merriweather 700</h3>
+  <h1>Heading 1 in 40px in Merriweather 700</h1>
+  <h2>Heading 2 in 30px in Merriweather 700</h2>
+  <h3>Heading 3 in 20px in Merriweather 700</h3>
+  <h4>Heading 4 in 17px in Merriweather 700</h4>
+  <h5>Heading 5 in 14px in Merriweather 700</h5>
 
   <!-- Body title -->
   <h3>Body</h3>
@@ -55,16 +53,14 @@ title: Typography
       </div>    
     </div>
 
-    <div class="usa-typography-examples">
-      <h1>Some important heading</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-      <h2>A section of the page</h2>
-      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
-      <h3>Subsection of the page</h3>
-      <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem ccusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.</p>
-      <h4>Subsection of the page</h4>
-      <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
-    </div>
+    <h1>Some important heading</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    <h2>A section of the page</h2>
+    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+    <h3>Subsection of the page</h3>
+    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem ccusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.</p>
+    <h4>Subsection of the page</h4>
+    <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
   </div>
 </div>
 

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -9,12 +9,14 @@ title: Typography
   <!-- Heading title -->
   <h3>Headings</h3>
 
-  <h3 class="usa-display">Display 52px in Merriweather 700</h3>
-  <h1>Heading 1 in 40px in Merriweather 700</h1>
-  <h2>Heading 2 in 30px in Merriweather 700</h2>
-  <h3>Heading 3 in 20px in Merriweather 700</h3>
-  <h4>Heading 4 in 17px in Merriweather 700</h4>
-  <h5>Heading 5 in 14px in Merriweather 700</h5>
+  <div class="usa-typography-examples">
+    <h3 class="usa-display">Display 52px in Merriweather 700</h3>
+    <h1>Heading 1 in 40px in Merriweather 700</h1>
+    <h2>Heading 2 in 30px in Merriweather 700</h2>
+    <h3>Heading 3 in 20px in Merriweather 700</h3>
+    <h4>Heading 4 in 17px in Merriweather 700</h4>
+    <h5>Heading 5 in 14px in Merriweather 700</h5>
+  </div>
 
   <!-- Body title -->
   <h3>Body</h3>
@@ -53,14 +55,16 @@ title: Typography
       </div>    
     </div>
 
-    <h1>Some important heading</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-    <h2>A section of the page</h2>
-    <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
-    <h3>Subsection of the page</h3>
-    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem ccusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.</p>
-    <h4>Subsection of the page</h4>
-    <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
+    <div class="usa-typography-examples">
+      <h1>Some important heading</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      <h2>A section of the page</h2>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
+      <h3>Subsection of the page</h3>
+      <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem ccusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis.</p>
+      <h4>Subsection of the page</h4>
+      <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
+    </div>
   </div>
 </div>
 

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -6,15 +6,15 @@
 $em-base:             10px; // default is already defined in bourbon
 $base-font-size:      rem(16px) !default;
 $small-font-size:     rem(14px) !default;
-$title-font-size:     rem(48px) !default;
-$h1-font-size:        rem(36px) !default;
-$h2-font-size:        rem(24px) !default;
-$h3-font-size:        rem(19px) !default;
-$h4-font-size:        rem(16px) !default;
+$title-font-size:     rem(52px) !default;
+$h1-font-size:        rem(40px) !default;
+$h2-font-size:        rem(30px) !default;
+$h3-font-size:        rem(20px) !default;
+$h4-font-size:        rem(17px) !default;
 $h5-font-size:        rem(14px) !default;
 $h6-font-size:        rem(12px) !default;
-$base-line-height:    1.5em !default;
-$heading-line-height: 1.3em !default;
+$base-line-height:    1.375em !default;
+$heading-line-height: 1.375em !default;
 
 $font-sans:           'Source Sans Pro', 'Helvetica', 'Arial', sans-serif !default;
 $font-serif:          'Merriweather', 'Georgia', 'Times New Roman', serif;

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -1,6 +1,6 @@
 // Typography
 $em-base:             10px;
-$base-font-size:      rem(16px);
+$base-font-size:      rem(17px);
 $small-font-size:     rem(14px);
 $title-font-size:     rem(52px);
 $h1-font-size:        rem(40px);

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -2,15 +2,15 @@
 $em-base:             10px;
 $base-font-size:      rem(16px);
 $small-font-size:     rem(14px);
-$title-font-size:     rem(48px);
-$h1-font-size:        rem(36px);
-$h2-font-size:        rem(24px);
-$h3-font-size:        rem(19px);
-$h4-font-size:        rem(16px);
+$title-font-size:     rem(52px);
+$h1-font-size:        rem(40px);
+$h2-font-size:        rem(30px);
+$h3-font-size:        rem(20px);
+$h4-font-size:        rem(17px);
 $h5-font-size:        rem(14px);
 $h6-font-size:        rem(12px);
-$base-line-height:    1.5em;
-$heading-line-height: 1.3em;
+$base-line-height:    1.375em;
+$heading-line-height: 1.375em;
 
 $font-sans:           'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
 $font-serif:          'Merriweather', 'Georgia', 'Times New Roman', serif;

--- a/assets/_scss/elements/_list.scss
+++ b/assets/_scss/elements/_list.scss
@@ -5,7 +5,6 @@ ul, ol {
   }
 
   li {
-    font-family: $font-serif;
     line-height: $base-line-height;
     margin: {
       top: .75em;

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -8,7 +8,6 @@ body {
 }
 
 p {
-  font-family: $font-serif;
   font-size: $base-font-size;
   line-height: $base-line-height;
   margin: {
@@ -37,11 +36,12 @@ a {
 
 h1, h2, h3, h4, h5, h6 {
   clear: both;
+  font-family: $font-serif;
+  line-height: $heading-line-height;
   margin: {
     top: 1.5em;
     bottom: .5em;
   }
-  line-height: $heading-line-height;
 }
 
 h5 {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -166,6 +166,10 @@ dfn {
   margin-left: 8%;
   position: absolute;
   top: 0;
+
+  .usa-display {
+    color: $color-white;
+  }
 }
 
 .usa-image-text {

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -166,10 +166,6 @@ dfn {
   margin-left: 8%;
   position: absolute;
   top: 0;
-
-  .usa-display {
-    color: $color-white;
-  }
 }
 
 .usa-image-text {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -456,6 +456,6 @@ h3 + .button_wrapper {
   background: #323a45
 }
 
-.usa-usfwds-heading {
+.usa-heading {
   color: $color-primary-darker;
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -456,12 +456,6 @@ h3 + .button_wrapper {
   background: #323a45
 }
 
-h2, h3 {
+.library-heading {
   color: $color-primary-darker;
-}
-
-.usa-typography-examples {
-  h2, h3 {
-    color: $color-base;
-  }
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -455,3 +455,13 @@ h3 + .button_wrapper {
 .button_wrapper-dark {
   background: #323a45
 }
+
+h2, h3 {
+  color: $color-primary-darker;
+}
+
+.usa-typography-examples {
+  h2, h3 {
+    color: $color-base;
+  }
+}

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -456,6 +456,6 @@ h3 + .button_wrapper {
   background: #323a45
 }
 
-.library-heading {
+.usa-usfwds-heading {
   color: $color-primary-darker;
 }

--- a/pages/about.html
+++ b/pages/about.html
@@ -4,7 +4,7 @@ layout: styleguide
 title: About
 ---
 
-<h1 class="usa-usfwds-heading">About</h1>
+<h1>About</h1>
 
 <p>Welcome to the alpha site for the U.S. Federal Web Design Standards project. </p>
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -4,7 +4,7 @@ layout: styleguide
 title: About
 ---
 
-<h1>About</h1>
+<h1 class="usa-usfwds-heading">About</h1>
 
 <p>Welcome to the alpha site for the U.S. Federal Web Design Standards project. </p>
 

--- a/pages/components.html
+++ b/pages/components.html
@@ -8,6 +8,6 @@ slug: components
 <h1>Components</h1>
 
 {% for component in site.components %}
-  <h2 id="{{ component.title | slugify }}">{{ component.title }}</h2>
+  <h2 class="usa-usfwds-heading" id="{{ component.title | slugify }}">{{ component.title }}</h2>
   <p>{{ component.content }}</p>
 {% endfor %}

--- a/pages/components.html
+++ b/pages/components.html
@@ -8,6 +8,6 @@ slug: components
 <h1>Components</h1>
 
 {% for component in site.components %}
-  <h2 class="usa-usfwds-heading" id="{{ component.title | slugify }}">{{ component.title }}</h2>
+  <h2 class="usa-heading" id="{{ component.title | slugify }}">{{ component.title }}</h2>
   <p>{{ component.content }}</p>
 {% endfor %}

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -8,6 +8,6 @@ slug: elements
 <h1>Elements</h1>
 
 {% for element in site.elements %}
-  <h2 id="{{ element.title | slugify }}">{{ element.title }}</h2>
+  <h2 class="usa-usfwds-heading" id="{{ element.title | slugify }}">{{ element.title }}</h2>
   <p>{{ element.content }}</p>
 {% endfor %}

--- a/pages/elements.html
+++ b/pages/elements.html
@@ -8,6 +8,6 @@ slug: elements
 <h1>Elements</h1>
 
 {% for element in site.elements %}
-  <h2 class="usa-usfwds-heading" id="{{ element.title | slugify }}">{{ element.title }}</h2>
+  <h2 class="usa-heading" id="{{ element.title | slugify }}">{{ element.title }}</h2>
   <p>{{ element.content }}</p>
 {% endfor %}

--- a/pages/layout-system.html
+++ b/pages/layout-system.html
@@ -8,6 +8,6 @@ slug: layout-system
 <h1>Layout System</h1> 
 
 {% for layout in site.layout-system %}
-  <h2 id="{{ layout.title | slugify }}">{{ layout.title }}</h2>
+  <h2 class="usa-usfwds-heading" id="{{ layout.title | slugify }}">{{ layout.title }}</h2>
   <p>{{ layout.content }}</p>
 {% endfor %}

--- a/pages/layout-system.html
+++ b/pages/layout-system.html
@@ -8,6 +8,6 @@ slug: layout-system
 <h1>Layout System</h1> 
 
 {% for layout in site.layout-system %}
-  <h2 class="usa-usfwds-heading" id="{{ layout.title | slugify }}">{{ layout.title }}</h2>
+  <h2 class="usa-heading" id="{{ layout.title | slugify }}">{{ layout.title }}</h2>
   <p>{{ layout.content }}</p>
 {% endfor %}

--- a/pages/visual-style.html
+++ b/pages/visual-style.html
@@ -8,6 +8,6 @@ slug: visual-style
 <h1>Visual Style</h1>
 
 {% for visual in site.visual %}
-  <h2 class="usa-usfwds-heading" id="{{ visual.title | slugify }}">{{ visual.title }}</h2>
+  <h2 class="usa-heading" id="{{ visual.title | slugify }}">{{ visual.title }}</h2>
   <p>{{ visual.content }}</p>
 {% endfor %}

--- a/pages/visual-style.html
+++ b/pages/visual-style.html
@@ -8,6 +8,6 @@ slug: visual-style
 <h1>Visual Style</h1>
 
 {% for visual in site.visual %}
-  <h2 id="{{ visual.title | slugify }}">{{ visual.title }}</h2>
+  <h2 class="usa-usfwds-heading" id="{{ visual.title | slugify }}">{{ visual.title }}</h2>
   <p>{{ visual.content }}</p>
 {% endfor %}


### PR DESCRIPTION
This updates the typography on the website to use our new font variables and defaults for sizes, font family, line height, and blue color on the usfwds site headings.

Here is what it looks like:
<img width="518" alt="screen shot 2015-08-19 at 9 12 18 am" src="https://cloud.githubusercontent.com/assets/5249443/9369852/dba53eba-4680-11e5-9f9c-2f0978c79e1e.png">

<img width="936" alt="screen shot 2015-08-19 at 9 14 12 am" src="https://cloud.githubusercontent.com/assets/5249443/9369853/dea6bdd2-4680-11e5-859d-299146f19aed.png">
