### PR TITLE
Updating to Jekyll 2.5.3 and removing auto-prefixer gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '2.4.0'
+gem 'jekyll'
 
 gem 'celluloid', '0.16.0'
 
 gem 'rouge'
 gem 'redcarpet'
-gem 'octopress-autoprefixer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    autoprefixer-rails (2.2.0.20140804)
-      execjs
     blankslate (2.1.2.4)
     celluloid (0.16.0)
       timers (~> 4.0.0)
@@ -13,11 +11,11 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     colorator (0.1)
-    execjs (2.5.2)
+    execjs (2.6.0)
     fast-stemmer (1.0.2)
     ffi (1.9.10)
     hitimes (1.2.2)
-    jekyll (2.4.0)
+    jekyll (2.5.3)
       classifier-reborn (~> 2.0)
       colorator (~> 0.1)
       jekyll-coffeescript (~> 1.0)
@@ -34,7 +32,7 @@ GEM
       toml (~> 0.1.0)
     jekyll-coffeescript (1.0.1)
       coffee-script (~> 2.2)
-    jekyll-gist (1.3.0)
+    jekyll-gist (1.3.3)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.3.0)
       sass (~> 3.2)
@@ -47,12 +45,6 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
     mercenary (0.3.5)
-    octopress-autoprefixer (1.0.1)
-      autoprefixer-rails (~> 2.2)
-      jekyll (>= 2.0)
-      octopress-hooks (~> 2.0)
-    octopress-hooks (2.6.1)
-      jekyll (>= 2.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
     posix-spawn (0.3.11)
@@ -63,7 +55,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
-    rouge (1.8.0)
+    rouge (1.9.1)
     safe_yaml (1.0.4)
     sass (3.4.16)
     timers (4.0.1)
@@ -77,10 +69,9 @@ PLATFORMS
 
 DEPENDENCIES
   celluloid (= 0.16.0)
-  jekyll (= 2.4.0)
-  octopress-autoprefixer
+  jekyll
   redcarpet
   rouge
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -31,9 +31,6 @@ sass:
   sass_dir: assets/_scss
 #  style: :compressed
 
-gems:
-- octopress-autoprefixer
-
 collections:
   visual:
     output: true


### PR DESCRIPTION
After some discussion with the rest of the front end team, we decided to remove auto-prefixer to our workflow for MVP. It seemed to cause other issues with our local dev environment, especially after rolling backwards to Jekyll 2.4.0. 

After merging, devs will need to run `bundle update` for this change to go into effect.