### PR TITLE
Add fix for button text color on visited links

### DIFF
--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -174,3 +174,12 @@ button,
     box-shadow: initial !important;
   }
 }
+
+// Fix for visited links
+
+a {
+  &.usa-button,
+  &.usa-button-primary {
+    color: $color-white;
+  }
+}

--- a/assets/_scss/elements/_buttons.scss
+++ b/assets/_scss/elements/_buttons.scss
@@ -2,6 +2,8 @@
 
 .usa-button,
 .usa-button-primary,
+.usa-button:visited,
+.usa-button-primary:visited,
 button,
 [type="button"],
 [type="submit"],
@@ -172,14 +174,5 @@ button,
   &:focus,
   &:hover {
     box-shadow: initial !important;
-  }
-}
-
-// Fix for visited links
-
-a {
-  &.usa-button,
-  &.usa-button-primary {
-    color: $color-white;
   }
 }


### PR DESCRIPTION
This adds a fix for visited links with the button class. 

This fixes #313.

This shows that the text is white and how the new class overrides the visited selector.

<img width="147" alt="screen shot 2015-08-21 at 3 38 03 pm" src="https://cloud.githubusercontent.com/assets/5249443/9420476/f679e4fc-481a-11e5-813f-4bd73d1e5371.png">
<img width="183" alt="screen shot 2015-08-21 at 3 39 02 pm" src="https://cloud.githubusercontent.com/assets/5249443/9420477/f67b2092-481a-11e5-80ca-2a0aea9aca8c.png">
