### PR TITLE
V2 accordions change in behavior

### DIFF
--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -5,6 +5,7 @@
     margin: 0;
     overflow: hidden;
     padding: 0;
+    width: 100%;
 
     li {
       background-color: $color-gray-lightest;

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -213,9 +213,7 @@ function Accordion($el) {
     var expanded = JSON.parse($(this).attr('aria-expanded'));
     ev.preventDefault();
     self.hideAll();
-    console.log('expanded', expanded);
     if (!expanded) {
-      console.log('show');
       self.show($(this));
     }
   });

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -210,9 +210,14 @@ function Accordion($el) {
   var self = this;
   this.$root = $el;
   this.$root.on('click', 'button', function(ev) {
+    var expanded = JSON.parse($(this).attr('aria-expanded'));
     ev.preventDefault();
     self.hideAll();
-    self.show($(this));
+    console.log('expanded', expanded);
+    if (!expanded) {
+      console.log('show');
+      self.show($(this));
+    }
   });
 }
 


### PR DESCRIPTION
This makes it so when an already opened item is clicked it will close
that item, not do nothing. The result of the attr if json parsed so
that its becomes an actual boolean.

The width on the ul was changed because before the content div was
setting the width, so when none are displaying it breaks the layout.