### PR TITLE
Add max width to text

### DIFF
--- a/_layouts/styleguide.html
+++ b/_layouts/styleguide.html
@@ -12,7 +12,7 @@
   	{% include sidenav.html %}
 
     <div class="main-content">
-      <article class="styleguide-content">
+      <article class="styleguide-content usa-content">
         {{ content }}
       </article>
 

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -11,8 +11,8 @@ $h1-font-size:        rem(40px) !default;
 $h2-font-size:        rem(30px) !default;
 $h3-font-size:        rem(20px) !default;
 $h4-font-size:        rem(17px) !default;
-$h5-font-size:        rem(14px) !default;
-$h6-font-size:        rem(12px) !default;
+$h5-font-size:        rem(15px) !default;
+$h6-font-size:        rem(13px) !default;
 $base-line-height:    1.375em !default;
 $heading-line-height: 1.375em !default;
 

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -7,8 +7,8 @@ $h1-font-size:        rem(40px);
 $h2-font-size:        rem(30px);
 $h3-font-size:        rem(20px);
 $h4-font-size:        rem(17px);
-$h5-font-size:        rem(14px);
-$h6-font-size:        rem(12px);
+$h5-font-size:        rem(15px);
+$h6-font-size:        rem(13px);
 $base-line-height:    1.375em;
 $heading-line-height: 1.375em;
 

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -121,7 +121,7 @@ dfn {
 // Custom typography
 
 .usa-content {
-  > p, > ul, > ol {
+  p, ul, ol {
     max-width: 50rem;
   }  
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -122,7 +122,7 @@ dfn {
 
 .usa-content {
   p, ul, ol {
-    max-width: 50rem;
+    max-width: 53rem;
   }  
 }
 

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -121,15 +121,7 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p, 
-  h1, 
-  h2, 
-  h3, 
-  h4, 
-  h5, 
-  h6, 
-  ul, 
-  ol {
+  p, ul, ol {
     max-width: 50rem;
   }  
 }

--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -121,7 +121,15 @@ dfn {
 // Custom typography
 
 .usa-content {
-  p, ul, ol {
+  p, 
+  h1, 
+  h2, 
+  h3, 
+  h4, 
+  h5, 
+  h6, 
+  ul, 
+  ol {
     max-width: 50rem;
   }  
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -286,11 +286,9 @@ a#skipnav {
     max-width: 50rem;
   }
   > h1 {
-    border-bottom: 1px solid #000;
-    padding-bottom: .5em;
     margin-top: 3.4rem;
     &:not(:first-child) {
-      margin-top: 2em;
+      margin-top: 1.5em;
     }
   }
   @media (min-width: $medium-screen + $width-nav-sidebar) {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -295,8 +295,8 @@ a#skipnav {
   }
   @media (min-width: $medium-screen + $width-nav-sidebar) {
     padding: {
-      left: 4em;
-      right: 4em;
+      left: 3em;
+      right: 3em;
     }
   }
 }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -282,9 +282,7 @@ a#skipnav {
   }  
   position: relative;
   padding-bottom: 1em;
-  > h2, > h3, > p, > ul, > ol {
-    max-width: 50rem;
-  }
+
   > h1 {
     margin-top: 3.4rem;
     &:not(:first-child) {

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -277,11 +277,11 @@ a#skipnav {
 
 .styleguide-content {
   padding: {
+    bottom: 1em;
     left: 2em;
     right: 2em;
   }  
   position: relative;
-  padding-bottom: 1em;
 
   > h1 {
     margin-top: 3.4rem;


### PR DESCRIPTION
This adds max width of 53rem or 530px to paragraph text and lists.

People can control this by using the `.usa-content` class. Using it will apply the max text width, not using it, applies a full width. 

*Note: make sure this is added to documentation

From @mollieru on https://trello.com/c/FbsCuH3b/382-1-component-pages-integrate-typography:

"Per our convo on using max 75 characters v. grid:

I'm leaning toward using the 75 character limit. This will keep us from needing to create multiple breakpoints for a grid."

This resolves: 

https://trello.com/c/9AcvLB29/397-1-component-page-set-max-width-for-paragraph-text

Example:

![screen shot 2015-08-28 at 12 52 42 pm](https://cloud.githubusercontent.com/assets/5249443/9555700/b8e21722-4d83-11e5-97bd-494a13c108fe.png)