### PR TITLE
Fix dropdown styles

### DIFF
--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -70,6 +70,8 @@ textarea {
 }
 
 select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
   appearance: none;
   background: url("../img/arrow-down.png") no-repeat;
   background-position: right 1.3rem center;


### PR DESCRIPTION
This re-adds browser vendor prefix to get dropdown / select element working again, since we've removed autoprefixer for now.