### PR TITLE
Add max-width to standards site

### DIFF
--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -273,9 +273,10 @@ a#skipnav {
   }
 }
 
-// Style Guide Content -------- //
+// Styleguide Content -------- //
 
 .styleguide-content {
+  max-width: $site-max-width;
   padding: {
     left: 2em;
     right: 2em;
@@ -861,3 +862,6 @@ code[class*="language-"], pre[class*="language-"] {
 .usa-code-sample pre[class*="language-"] {
   margin-top: 0;
 }
+
+// Max width for styleguide
+

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -862,6 +862,3 @@ code[class*="language-"], pre[class*="language-"] {
 .usa-code-sample pre[class*="language-"] {
   margin-top: 0;
 }
-
-// Max width for styleguide
-


### PR DESCRIPTION
This adds max-width to the standards site.

This resolves: https://trello.com/c/lDhZ8jvI/396-1-site-design-set-max-width-for-site

This is what it looks like:

![screen shot 2015-08-28 at 11 24 42 am](https://cloud.githubusercontent.com/assets/5249443/9553968/77c51020-4d77-11e5-82a1-153e6c33287d.png)