### PR TITLE
Place medium and small search bar in 1/2 width grid boxes

### DIFF
--- a/_components/search-bar.md
+++ b/_components/search-bar.md
@@ -19,7 +19,7 @@ title: Search Bar
   </div>
 
   <div class="usa-grid">
-    <div class="usa-width-one-fourth">
+    <div class="usa-width-one-half">
       <form class="usa-search">
         <label for="search-field">Search Medium</label>
         <input type="search" id="search-field">
@@ -31,7 +31,7 @@ title: Search Bar
   </div>
 
   <div class="usa-grid">
-    <div class="usa-width-one-fourth">
+    <div class="usa-width-one-half">
       <form class="usa-search usa-search-small">
         <label for="search-field-small">Search Small</label>
         <input type="search" id="search-field-small">


### PR DESCRIPTION
This updates the medium and small search bar size to use the 1/2 width. 

This resolves: https://trello.com/c/EWt0FVSa/439-place-medium-and-small-header-in-1-2-width-grid-boxes

This is what it looks like:
![screen shot 2015-08-28 at 2 16 49 pm](https://cloud.githubusercontent.com/assets/5249443/9557324/f08d1198-4d8f-11e5-8e73-511e6cfdbede.png)
