### PR TITLE
Update navbar to full width

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -3,12 +3,10 @@
 <header class="usa-site-header" role="banner">
 
   <div class="usa-disclaimer">
-    <div class="usa-grid">
-      <span class="usa-disclaimer-official">An official website of the United States Government 
-        <img alt="US flag signifying that this is a United States Federal Government website" src="{{ site.baseurl }}/assets/img/us_flag_small.png">
-      </span>
-      <span class="usa-disclaimer-stage">This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></span>
-    </div>
+    <span class="usa-disclaimer-official">An official website of the United States Government 
+      <img alt="US flag signifying that this is a United States Federal Government website" src="{{ site.baseurl }}/assets/img/us_flag_small.png">
+    </span>
+    <span class="usa-disclaimer-stage">This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></span>
   </div>
   
     <nav class="usa-site-navbar">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -12,9 +12,8 @@
   </div>
   
     <nav class="usa-site-navbar">
-      <div class="usa-grid">
       <a href="#" id="menu-btn">&#9776; MENU</a>
-      <div id="logo">
+      <div class="logo" id="logo">
         <a href="{{ site.baseurl }}/" accesskey="1" title="Home" aria-label="Home">
           <h1>U.S. Federal Web Design Standards</h1>
         </a>
@@ -29,7 +28,6 @@
           </a>
           </li>
       </ul>
-      </div>
     </nav>
   
 </header>

--- a/assets/_scss/core/_defaults.scss
+++ b/assets/_scss/core/_defaults.scss
@@ -80,7 +80,7 @@ $large-screen:      1201px !default;
 
 // Magic Numbers
 $site-max-width:    1040px !default;
-$site-margins:      40px !default;
+$site-margins:      3rem !default;
 $article-max-width: 600px !default;
 $input-max-width:   46rem !default;
 $border-radius:     rem(3px) !default;

--- a/assets/_scss/core/_variables.scss
+++ b/assets/_scss/core/_variables.scss
@@ -76,7 +76,7 @@ $large-screen:      1201px;
 
 // Magic Numbers
 $site-max-width:    1040px;
-$site-margins:      40px;
+$site-margins:      3rem;
 $article-max-width: 600px;
 $input-max-width:   46rem;
 $border-radius:     rem(3px);

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -47,10 +47,19 @@ a#skipnav {
   background-color: $color-white;
   border-bottom: 1px solid $color-gray-light;
   z-index: 1;
+  
   a {
     border-bottom: none;
-//    color: white;
   }
+
+  .usa-disclaimer-official {
+    padding-left: $site-margins;
+  }
+
+  .usa-disclaimer-stage {
+    padding-right: $site-margins;
+  }
+
   .usa-site-navbar {
     @include media($medium-screen) {
       height: 6rem;
@@ -59,9 +68,11 @@ a#skipnav {
         top: 2.7rem;
       }
     }
+
     .logo {
         padding-left: $site-margins;
       }
+
     h1 {
       @include media($medium-screen) {
 
@@ -76,17 +87,19 @@ a#skipnav {
         display: block;
       }
     }
+
     .usa-button-list {
-      float: right;
-      display: none;
-      margin-top: -5px;
-      li { 
-        display: inline; 
-        font-family: $font-sans;
-      }
       @include media($medium-screen + $width-nav-sidebar) {
         display: block;
         padding-right: $site-margins;
+      }
+      float: right;
+      display: none;
+      margin-top: -5px;
+      
+      li { 
+        display: inline; 
+        font-family: $font-sans;
       }
     }
   }

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -53,13 +53,18 @@ a#skipnav {
   }
   .usa-site-navbar {
     @include media($medium-screen) {
+      height: 6rem;
       margin: {
         bottom: 1rem;
-        top: 2.5rem;
+        top: 2.7rem;
       }
     }
+    .logo {
+        padding-left: $site-margins;
+      }
     h1 {
       @include media($medium-screen) {
+
         max-width: 20rem;
       }
       color: $color-gray;
@@ -81,6 +86,7 @@ a#skipnav {
       }
       @include media($medium-screen + $width-nav-sidebar) {
         display: block;
+        padding-right: $site-margins;
       }
     }
   }


### PR DESCRIPTION
Removes the grid inside and updates the site navbar to extend full width. Logo and download button will always float left and right, as do text in disclaimer.

This resolves: https://trello.com/c/oexWJr21/408-3-site-header-update-header

This is what it looks like:

<img width="1203" alt="screen shot 2015-08-28 at 5 00 20 pm" src="https://cloud.githubusercontent.com/assets/5249443/9559329/5bf4aee4-4da6-11e5-9557-f02716d49283.png">