### PR TITLE
Add margin bottom to preview-no_border

### DIFF
--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -350,7 +350,10 @@ a#skipnav {
 
 .preview-no_border {
   border: 0;
-  margin: 0;
+  margin: {
+    top: 0;
+    bottom: 2em;
+  }
   padding: 0;
 }
 


### PR DESCRIPTION
Adds margin bottom to `preview-no_border`, so the code snippet doesn't run up to the bottom of the sample.