### PR TITLE
Scroll entire doc, instead of just main content

### DIFF
--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -204,16 +204,9 @@ a#skipnav {
   bottom: 0;
   left: 0;
   width: $width-nav-sidebar;
-<<<<<<< HEAD
   border-right: 1px solid $color-gray-light;
   padding: 5rem 3rem 3rem 3rem;
   overflow: scroll;
-=======
-  background-color: #fafafa;
-  border-right: 1px solid #eeeeee;
-  padding: 5rem 2em 2em;
-  overflow-y: scroll;
->>>>>>> FETCH_HEAD
   display: none;
   z-index: -1;
   

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -43,9 +43,30 @@ a#skipnav {
   }
 }
 
+:target:before {
+  content: "";
+  display: block;
+  height: 75px;
+  margin-top: -75px;
+
+  @include media($medium-screen) {
+    height: 90px;
+    margin-top: -90px;
+  }
+
+  @include media($medium-screen + $width-nav-sidebar) {
+    height: $site-top;
+    margin-top: -$site-top;
+  }
+}
+
 .usa-site-header {
   background-color: $color-white;
   border-bottom: 1px solid $color-gray-light;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
   z-index: 1;
   
   a {
@@ -178,14 +199,14 @@ a#skipnav {
 // Sidebar Nav --------- //
 
 .sidenav {
-  position: absolute;
+  position: fixed;
   top: $site-top;
   bottom: 0;
   left: 0;
   width: $width-nav-sidebar;
   border-right: 1px solid $color-gray-light;
   padding: 5rem 3rem 3rem 3rem;
-  overflow: auto;
+  overflow: scroll;
   display: none;
   z-index: -1;
   
@@ -232,7 +253,6 @@ a#skipnav {
   top: 4rem;
   bottom: 0;
   right: 0;
-  overflow: auto;
   width: 100%;
   padding: {
     bottom: 0;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,8 +49,23 @@ $(function(){
 $('.secondary-sidenav-link').click(function(e) {
   e.preventDefault();
   var hashLocation = $(this).attr('href').split('#')[1]; // long url splitting
-  $('.main-content').animate({
-    scrollTop: $('#' + hashLocation).position().top +35
-  }, 200);
-  window.location.hash = hashLocation;
+  var anchor       = $('#' + hashLocation);
+  var headerOffset = 0;
+
+  /* :target already adds spacing to line up the page correctly
+   * prevent double space if current page target already = new target
+   */
+  if (!anchor.is(":target")) {
+    headerOffset = ($('.usa-site-header').first().outerHeight());
+  }
+
+  /* Firefox needs html, others need body */
+  $('body,html').animate({
+    scrollTop: anchor.offset().top - headerOffset
+  }, {
+    duration: 200,
+    always: function () {
+      window.location.hash = hashLocation;
+    }
+  });
 });


### PR DESCRIPTION
Tested in Chorme, FF, Safari. iOS 7.1 & 8.4 on both iPad and iPhone. Seems to work pretty well, much smoother scrolling. Need some help testing on an android device.

(this is basically PR #383, again, but I did something weird with that one)