### PR TITLE
Update accordion

### DIFF
--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -19,21 +19,14 @@
     button[aria-expanded=false] {
       background-image: url('../img/plus.png');
       background-image: url('../img/plus.svg');
-      background-position: 90.5%;
       background-repeat: no-repeat;
       background-size: 13px;
-      @include media($small-screen) {
-        background-position: 96.5%;
-      }
     }
 
     button {
-      @include media($small-screen) {
-        background-position: 96.5%;
-      }
       background-image: url('../img/minus.png');
       background-image: url('../img/minus.svg');
-      background-position: 90.5%;
+      background-position: right $site-margins center;
       background-repeat: no-repeat;
       background-size: 13px;
       color: $color-base;

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -47,14 +47,12 @@
       }
     }
   }
-
 }
 
 .usa-accordion-bordered {
   .usa-accordion-content {
     border: 3px solid $color-gray-lightest;
   }
-  
 }
 
 .usa-accordion-content {

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -51,7 +51,11 @@
 
 .usa-accordion-bordered {
   .usa-accordion-content {
-    border: 3px solid $color-gray-lightest;
+    border: {
+      bottom: 3px solid $color-gray-lightest;
+      left: 3px solid $color-gray-lightest;
+      right: 3px solid $color-gray-lightest;
+    }
   }
 }
 

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -26,7 +26,7 @@
     button {
       background-image: url('../img/minus.png');
       background-image: url('../img/minus.svg');
-      background-position: right $site-margins center;
+      background-position: right 3rem center;
       background-repeat: no-repeat;
       background-size: 13px;
       color: $color-base;

--- a/assets/_scss/components/_accordions.scss
+++ b/assets/_scss/components/_accordions.scss
@@ -51,7 +51,6 @@
 }
 
 .usa-accordion-bordered {
-
   .usa-accordion-content {
     border: 3px solid $color-gray-lightest;
   }


### PR DESCRIPTION
This makes a few improvements to the accordion.

1.) this changes the positioning of the plus/minus icon to always be 3rem from the right, before it was a percentage that changed multiple times for different screen sizes. 
2.) removes the top border on the expanded border example

Now:

![screen shot 2015-08-31 at 2 46 56 pm](https://cloud.githubusercontent.com/assets/5249443/9591338/9dcf3aa0-4fef-11e5-9394-0d790e13aa9c.png)

Before:

![screen shot 2015-08-31 at 2 18 55 pm](https://cloud.githubusercontent.com/assets/5249443/9591383/d4c24002-4fef-11e5-8c2b-e4fd8c67a117.png)
