### PR TITLE
Replaced correct hex code in color label

### DIFF
--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -188,7 +188,7 @@ order: 02
   <div class="color-big">
     <div class="usa-color-short usa-color-primary-darkest">
     </div>
-      <p class="usa-color-hex">#046b99</p>
+      <p class="usa-color-hex">#112e51</p>
       <p class="usa-color-name">primary-darkest</p>
   </div>
   <div class="color-small usa-end-row">


### PR DESCRIPTION
The hex code in the label before was for `primary-alt-darkest`.

This fix corrects it for the darkest blue color.
Hope I'm doing this right, it seemed to make it easier on you all then filing an issue. 