### PR TITLE
Add current page to side navigation

### DIFF
--- a/_components/sidenav.md
+++ b/_components/sidenav.md
@@ -13,7 +13,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
     <aside class="usa-width-one-fourth">
       <ul class="usa-sidenav-list">
         <li>
-          <a class="usa-current-page" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="javascript:void(0)">Current page</a>
         </li>
         <li>
           <a href="javascript:void(0)">Secondary link</a>
@@ -34,7 +34,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
           <a href="javascript:void(0)">Secondary link</a>
         </li>
         <li>
-          <a class="usa-current-page" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="javascript:void(0)">Current page</a>
           <ul class="usa-sidenav-sub_list">
             <li>
               <a href="javascript:void(0)">Headers & Navigation</a>
@@ -49,7 +49,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
               <a href="javascript:void(0)">Tables</a>
             </li>
             <li>
-              <a class="usa-current-page" href="javascript:void(0)">Accordion</a>
+              <a class="usa-current" href="javascript:void(0)">Accordion</a>
             </li>
           </ul>
         </li>
@@ -69,7 +69,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
           <a href="javascript:void(0)">Secondary link</a>
         </li>
         <li>
-          <a class="usa-current-page" href="javascript:void(0)">Current page</a>
+          <a class="usa-current" href="javascript:void(0)">Current page</a>
           <ul class="usa-sidenav-sub_list">
             <li>
               <a href="javascript:void(0)">Headers & Navigation</a>
@@ -84,7 +84,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
                   <a href="javascript:void(0)">Grandchild 2</a>
                 </li>
                 <li>
-                  <a class="usa-current-page" href="javascript:void(0)">Grandchild 3</a>
+                  <a class="usa-current" href="javascript:void(0)">Grandchild 3</a>
                 </li>
               </ul>
             </li>

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,14 +1,13 @@
-{% assign components = site.patterns | where:"type","component" %}
-{% assign elements = site.patterns | where:"type","element" %}
+{% assign current = page.url | downcase | split: '/' %}
 
 <aside class="sidenav" id="menu-content">
   <nav>
     <ul class="usa-sidenav-list">
       <li>
-        <a href="{{ site.baseurl }}/getting-started/">Getting started</a>
+        <a {% if current[1] == 'getting-started' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/getting-started/">Getting started</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/visual-style/">Visual style</a>
+        <a {% if current[1] == 'visual-style' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/visual-style/">Visual style</a>
         <ul class="usa-sidenav-sub_list visual-style-sublist">
           <li>
             <a href="{{ site.baseurl }}/visual-style/#typography">Typography</a>
@@ -44,25 +43,25 @@
         </ul>
       </li> 
       <li>
-        <a href="{{ site.baseurl }}/grids/">Grids</a>
+        <a {% if current[1] == 'grids' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/grids/">Grids</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/buttons/">Buttons</a>
+        <a {% if current[1] == 'buttons' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/buttons/">Buttons</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/labels/">Labels</a>
+        <a {% if current[1] == 'labels' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/labels/">Labels</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/tables/">Tables</a>
+        <a {% if current[1] == 'tables' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/tables/">Tables</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/alerts/">Alerts</a>
+        <a {% if current[1] == 'alerts' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/alerts/">Alerts</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/accordions/">Accordions</a>
+        <a {% if current[1] == 'accordions' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/accordions/">Accordions</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/form-controls/">Form controls</a>
+        <a {% if current[1] == 'form-controls' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/form-controls/">Form controls</a>
         <ul class="usa-sidenav-sub_list form-controls-sublist">
           <li>
             <a href="{{ site.baseurl }}/form-controls/#text-inputs">Text inputs and area</a>
@@ -82,7 +81,7 @@
         </ul>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/form-templates/">Form templates</a>
+        <a {% if current[1] == 'form-templates' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/form-templates/">Form templates</a>
         <ul class="usa-sidenav-sub_list form-templates-sublist">
           <li>
             <a href="{{ site.baseurl }}/form-templates/#name-form">Name form</a>
@@ -105,13 +104,13 @@
         </ul>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/search-bar/">Search bar</a>
+        <a {% if current[1] == 'search-bar' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/search-bar/">Search bar</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/sidenav/">Side navigation</a>
+        <a {% if current[1] == 'sidenav' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/sidenav/">Side navigation</a>
       </li>
       <li>
-        <a href="{{ site.baseurl }}/footers/">Footers</a>
+        <a {% if current[1] == 'footers' %}class="usa-current"{% endif %} href="{{ site.baseurl }}/footers/">Footers</a>
         <ul class="usa-sidenav-sub_list footers-sublist">
           <li>
             <a href="{{ site.baseurl }}/footers/#big-footer">Big footer</a>

--- a/assets/_scss/components/_sidenav.scss
+++ b/assets/_scss/components/_sidenav.scss
@@ -33,12 +33,12 @@
       text-decoration: none;
     }
 
-    &.usa-current-page {
+    &.usa-current {
       color: $color-primary;
       font-weight: $font-bold;
     }
 
-    &.usa-current-page {
+    &.usa-current {
       border-left: 4px solid $color-primary;
       padding-left: 1.4rem;
     }
@@ -59,7 +59,7 @@
   }
 
   a:hover,
-  a.usa-current-page {
+  a.usa-current {
     border: none;
     padding-left: 2.8rem;
   }


### PR DESCRIPTION
This adds the current page to the sidebar navigation so users can know what page they're in.

This is what it looks like:

<img width="224" alt="screen shot 2015-09-08 at 9 58 57 am" src="https://cloud.githubusercontent.com/assets/5249443/9741629/415c9098-5610-11e5-8e16-c286c7bfd4e7.png">
