### PR TITLE
Add conditional comment to polyfills

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -61,8 +61,3 @@
   <link rel="stylesheet" href="{{ "/assets/css/google-fonts.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/assets/css/prism.css" | prepend: site.baseurl }}">
   <link rel="stylesheet" href="{{ "/assets/css/styleguide.css" | prepend: site.baseurl }}">
-
-
-<!-- Scripts
-================================================== -->
-  <script src="{{ site.baseurl }}/assets/js/vendor/jquery-1.11.3.min.js"></script>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,4 @@
+  <script src="{{ site.baseurl }}/assets/js/vendor/jquery-1.11.3.min.js"></script>
   <!--[if lt IE 9]>
     <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
     <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
@@ -6,4 +7,3 @@
   <![endif]-->
   <script src="{{ site.baseurl }}/assets/js/vendor/prism.js"></script>
   <script src="{{ site.baseurl }}/assets/js/main.js"></script>
-  

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,7 +1,9 @@
-  <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/rem.min.js"></script>
+  <!--[if lt IE 9]>
+    <script src="{{ site.baseurl }}/assets/js/vendor/html5shiv.js"></script>
+    <script src="{{ site.baseurl }}/assets/js/vendor/selectivizr-min.js"></script>
+    <script src="{{ site.baseurl }}/assets/js/vendor/respond.js"></script>
+    <script src="{{ site.baseurl }}/assets/js/vendor/rem.min.js"></script>
+  <![endif]-->
   <script src="{{ site.baseurl }}/assets/js/vendor/prism.js"></script>
   <script src="{{ site.baseurl }}/assets/js/main.js"></script>
-
+  


### PR DESCRIPTION
This adds a conditional comment to our polyfill scripts so that they will only be used by browsers that are less than IE9. Before it was being used by all browsers.

Also this moves the jQuery script out of the head and into the scripts include, which goes before the closing `</body>` tag of the site.