### PR TITLE
Add class to documentation accordions on visual style

### DIFF
--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -367,7 +367,7 @@ order: 02
 
 <h5>Neutrals on a colored background</h5>
 
-<div class="usa-grid-full">
+<div class="usa-grid-full usa-color-bg-example">
   <div class="usa-width-one-half">
     <div class="usa-color-text usa-color-base usa-color-text-white">
       white on base

--- a/_visual/colors.md
+++ b/_visual/colors.md
@@ -461,7 +461,7 @@ order: 02
   </div>
 </div>
 
-<div class="usa-accordion-bordered">
+<div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
       aria-expanded="true" aria-controls="collapsible-0">
     Documentation

--- a/_visual/typography.md
+++ b/_visual/typography.md
@@ -728,7 +728,7 @@ Include intro of the two families, how we have diff packages, a bit on considera
   </ul>
 </div>
 
-<div class="usa-accordion-bordered usa-typography-example">
+<div class="usa-accordion-bordered usa-typography-example usa-accordion-docs">
   <ul class="usa-unstyled-list">
     <li>
       <button class="usa-button-unstyled"
@@ -927,7 +927,7 @@ Include intro of the two families, how we have diff packages, a bit on considera
 
 <!-- Typsetting section end -->
 
-<div class="usa-accordion-bordered">
+<div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
       aria-expanded="true" aria-controls="collapsible-0">
     Documentation
@@ -984,7 +984,7 @@ Include intro of the two families, how we have diff packages, a bit on considera
 
 <!-- Links section end -->
 
-<div class="usa-accordion-bordered">
+<div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
       aria-expanded="true" aria-controls="collapsible-0">
     Documentation
@@ -1056,7 +1056,7 @@ Include intro of the two families, how we have diff packages, a bit on considera
 
 <!-- Lists section end -->
 
-<div class="usa-accordion-bordered">
+<div class="usa-accordion-bordered usa-accordion-docs">
   <button class="usa-button-unstyled usa-accordion-button"
       aria-expanded="true" aria-controls="collapsible-0">
     Documentation

--- a/assets/css/styleguide.scss
+++ b/assets/css/styleguide.scss
@@ -959,6 +959,10 @@ code[class*="language-"], pre[class*="language-"] {
   }
 }
 
+.usa-color-bg-example {
+  margin-bottom: 3rem;
+}
+
 // Alt font styles
 
 $font-light: 300;


### PR DESCRIPTION
This adds the `usa-accordion-docs` class on to the documentation accordions in visual style, giving it proper spacing.

Also adds a little padding on the color example that was a little tight.