### PR TITLE
Corrected the link to the form templates accessibility section

### DIFF
--- a/_elements/form-controls.md
+++ b/_elements/form-controls.md
@@ -16,7 +16,7 @@ lead: Intro text on what is included in this section and how to use it. No more 
   <li>If the color scheme of the buttons are adjusted ensure all states have a minimum contrast ratio of 4.5:1 (for small text, 3:1 for large) for all states of the button. This includes default, hover, selected, disabled.</li>
 </ul>
 
-<p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/components/#forms-blocks">accessibility guidelines in the “Common Form Templates” section</a>.</p>
+<p>If you are a building a form with multiple controls, also consider the <a href="{{ site.baseurl }}/form-controls/">accessibility guidelines in the “Form Templates” section</a>.</p>
 
 <h2 class="usa-heading" id="text-inputs">Text Input</h2>
 


### PR DESCRIPTION
Discovered that after the nav changes the link was taking you to a weird page. This fixes it. Also updated the text of the link to more closely match the navigation text.