### PR TITLE
Add focus state to anchor links

### DIFF
--- a/assets/_scss/elements/_typography.scss
+++ b/assets/_scss/elements/_typography.scss
@@ -26,7 +26,12 @@ a {
 
   &:visited {
     color: $color-visited;
-  }  
+  }
+
+  &:focus {
+    box-shadow: $focus-shadow;
+    outline: 0;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
This adds focus state to anchor links. This also removes the browser default outline in favor of our design and so there are not two duplicate focus states overlapping. 

This resolves: #443 and #421.

Text links:
<img width="397" alt="screen shot 2015-09-09 at 9 02 08 pm" src="https://cloud.githubusercontent.com/assets/5249443/9779992/8a103ca4-5737-11e5-9fe7-9c6e33cc7c6c.png">

Sidenav:
<img width="217" alt="screen shot 2015-09-09 at 9 01 48 pm" src="https://cloud.githubusercontent.com/assets/5249443/9779999/915e4d2a-5737-11e5-9928-797154ae3893.png">

Firefox:
<img width="724" alt="screen shot 2015-09-09 at 9 08 34 pm" src="https://cloud.githubusercontent.com/assets/5249443/9780002/9d450480-5737-11e5-8650-b55136b48d18.png">
