### PR TITLE
Add focus state for radio buttons

### DIFF
--- a/assets/_scss/elements/_inputs.scss
+++ b/assets/_scss/elements/_inputs.scss
@@ -153,6 +153,10 @@ input[type="radio"]:checked + label::before {
   box-shadow: 0 0 0 2px $color-white, 0 0 0 4px $color-primary; 
 }
 
+input[type="radio"]:focus + label::before {
+  box-shadow: 0 0 0 2px $color-white, 0 0 0 4px $color-primary, 0 0 3px 4px $color-focus, 0 0 7px 4px $color-focus;
+}
+
 input[type="checkbox"]:checked + label::before {
   background-image: url('../img/correct8.png');
   background-image: url('../img/correct8.svg');


### PR DESCRIPTION
This adds the focus state for radio buttons.

This resolves: #413.

This is what is looks like:

<img width="289" alt="screen shot 2015-09-09 at 9 40 18 pm" src="https://cloud.githubusercontent.com/assets/5249443/9780269/9439d696-573b-11e5-8080-42fce9220082.png">

![](http://g.recordit.co/ZdqeKygCKe.gif)