### PR TITLE
Remove top and bottom padding on input

### DIFF
--- a/assets/_scss/components/_search.scss
+++ b/assets/_scss/components/_search.scss
@@ -24,6 +24,10 @@ $usa-btn-big-width:     11.6rem;
     float: left;
     height: 3.3rem;
     margin: 0;
+    padding: {
+      bottom: 0;
+      top: 0;
+    }
     width: calc(100% - #{$usa-btn-small-width});
 
     @include media($small-screen) {


### PR DESCRIPTION
This removes padding from the input on search bars.

This resolves: https://github.com/18F/usfwds/issues/417

This is what it looks like in Firefox:

![screen shot 2015-09-10 at 4 54 09 pm](https://cloud.githubusercontent.com/assets/5249443/9803902/988cd74c-57dc-11e5-9f53-46e63fa4bbb5.png)
